### PR TITLE
A quick fix to the headers in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Global WordNet Grid LMF parser
+# Global WordNet Grid LMF parser
 
 This repo provides a python module to work with Open Dutch WordNet.
 Please first check the [Issues](https://github.com/MartenPostma/OpenDutchWordnet/issues) to see if your question has already
@@ -24,7 +24,7 @@ A demo for word similarity using Open Dutch WordNet can be found [here](http://1
 In the background, this uses the [WordNetTools](https://github.com/cltl/WordnetTools/). We encourage to use the module locally
 when you need to run for many word pairs.
 
-##USAGE AND INSTALL
+## USAGE AND INSTALL
 git clone this repository.
 
 The python module 'lxml' is needed. Hopefully, 'pip install lxml'
@@ -79,8 +79,9 @@ python
 >>> relation_el.get_target()
 'eng-30-00322847-v'
 
-```	                  
-##Contact
+```
+
+## Contact
 * Marten Postma
 * m.c.postma@vu.nl
 * http://martenpostma.com/


### PR DESCRIPTION
Headers in markdown need a space between the `#`'s and the text. This is just fixing the headers that didn't have that.

Thanks for creating this for the Dutch language, definitely going to be useful!